### PR TITLE
Bump upper bound on dependency: text

### DIFF
--- a/pipes-shell.cabal
+++ b/pipes-shell.cabal
@@ -68,7 +68,7 @@ library
                  , process >=1.2 && <1.3
                  , stm >=2.4 && <2.5
                  , stm-chans >= 3.0.0 && <3.1
-                 , text >= 0.11.3.0 && <1.2
+                 , text >= 0.11.3.0 && <1.3
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -100,7 +100,7 @@ test-suite spec
                  , process >=1.2 && <1.3
                  , stm >=2.4 && <2.5
                  , stm-chans >= 3.0.0 && <3.1
-                 , text >= 0.11.3.0 && <1.2
+                 , text >= 0.11.3.0 && <1.3
 
   -- Directories containing source files.
   hs-source-dirs:  src, test


### PR DESCRIPTION
The package compiles fine with the 1.2.x version of Data.Text